### PR TITLE
Write example using annotate-equation

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -38,6 +38,7 @@
 \usepackage{multirow}
 \usepackage{snotez}     % For sidenote environments. enotez for endnotes
 \usepackage{csquotes}   % For language-based quote rules (helps BiBLaTeX)
+\usepackage{annotate-equations}
 
 % Make declarations
 \DeclareSIUnit\Molar{M}

--- a/src/chapters/introduction.tex
+++ b/src/chapters/introduction.tex
@@ -46,6 +46,18 @@ S_n = \frac{X_1 + X_2 + \cdots + X_n}{n}
 \end{equation}
 denote their mean. Then as $n$ approaches infinity, the random variables $\sqrt{n}(S_n - \mu)$ converge in distribution to a normal $\mathcal{N}(0, \sigma^2)$.
 
+You can even get extra fancy and annotate your equations directly: %this uses the `annotate-equations` package. See `https://ctan.org/pkg/annotate-equations` for further info and ideas
+
+\vspace{1.5em} 
+\begin{equation}
+\label{eq:CLT2}
+S_n = \frac{\eqnmarkbox[blue]{a1}{X_1 + X_2 + \cdots + X_n}}{n}
+      = \frac{1}{n}\sum_{i}^{n} \eqnmarkbox[purple]{a2}{X_i}
+\end{equation}
+\annotate[yshift=1em]{above}{a1}{independent and identically distributed random variables}
+\annotate[yshift=-1em]{below,left}{a2}{a random variable}
+\vspace{1.5em} 
+
 \lipsum[3] 
 
 \begin{figure}


### PR DESCRIPTION
Resolves #27 

I opted to add a whole copy of the equation example rather than just edit the existing one, because adding annotations makes it a little messy, and probably overwhelming to someone who is new to LaTeX. 

_Note: I haven't added a new pdf to this commit - I don't know what the project norm is on how often to update that in response to new commits_