### PR TITLE
biblatex tweaks

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -53,6 +53,8 @@
 	natbib=true,		% allow natbib commands
 	hyperref=true,	    % activate hyperref support
 	alldates=year,      % only show year (not month)
+    uniquename=false,   % don't add firstnames when citing multiple sources by the same author
+    maxbibnames=12,     % maximum number of author names to list in bibliography before 'et al' is used instead
 ]{biblatex}
 
 % Just avoiding some rogue fields that cause issues with certain styles 

--- a/main.tex
+++ b/main.tex
@@ -54,7 +54,7 @@
 	hyperref=true,	    % activate hyperref support
 	alldates=year,      % only show year (not month)
     uniquename=false,   % don't add firstnames when citing multiple sources by the same author
-    maxbibnames=12,     % maximum number of author names to list in bibliography before 'et al' is used instead
+    maxbibnames=99,     % maximum number of author names to list in bibliography before 'et al' is used instead
 ]{biblatex}
 
 % Just avoiding some rogue fields that cause issues with certain styles 


### PR DESCRIPTION
I think `uniquenames` means that if I cite two articles, one by J. Bloggs and one by John Bloggs, biblatex will assume that they are different people, and thus use their full names inline to differentiate. This is rarely useful behavior in my opinion.

`maxbibnames` seems to default to 3, which is too low for modern collaborative projects in my opinion. 12 seems a reasonable (yet still arbitrary) cut-off.